### PR TITLE
修正日誌控制器命名衝突

### DIFF
--- a/ECommercePlatform/Controllers/Admin/LogsController.cs
+++ b/ECommercePlatform/Controllers/Admin/LogsController.cs
@@ -1,14 +1,14 @@
-using Microsoft.AspNetCore.Mvc;
-using ECommercePlatform.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using ECommercePlatform.Data;
 
-namespace ECommercePlatform.Controllers
+namespace ECommercePlatform.Controllers.Admin
 {
+    [Authorize(AuthenticationSchemes = "EngineerCookie")]
+    [Route("admin/logs")]
     public class LogsController : Controller
     {
-}
         private readonly ApplicationDbContext _dbContext;
 
         // 建構子，將 ApplicationDbContext 注入

--- a/ECommercePlatform/Controllers/Api/LogsApiController.cs
+++ b/ECommercePlatform/Controllers/Api/LogsApiController.cs
@@ -1,17 +1,15 @@
 using Microsoft.AspNetCore.Mvc;
-using ECommercePlatform.Models;
 using ECommercePlatform.Data;
-using Microsoft.AspNetCore.Authorization;
 
-namespace ECommercePlatform.Controllers
+namespace ECommercePlatform.Controllers.Api
 {
-}
-    public class LogsControllerV2 : Controller // 已更名以避免重複定義
+    [ApiController]
+    [Route("api/logs")]
+    public class LogsApiController : ControllerBase
     {
         private readonly ApplicationDbContext _context;
 
-        // 建構子，注入資料庫內容
-        public LogsControllerV2(ApplicationDbContext context)
+        public LogsApiController(ApplicationDbContext context)
         {
             _context = context;
         }


### PR DESCRIPTION
## Summary
- 將原本為 `LogsControllerV2` 的檔案移至 `Api` 資料夾並更名為 `LogsApiController`
- 整理 `Admin/LogsController` 的類別結構與路由，統一使用工程師驗證

## Testing
- `dotnet build --no-restore` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684031ac0bdc83228b1990676e65e6e3